### PR TITLE
Nuke frameworks if Podfile.lock has changed

### DIFF
--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -166,29 +166,25 @@ def cache_frameworks(parent)
   cached_podfile_lock = File.join(parent, "Rome", "Podfile.lock")
 
   if File.file?(new_podfile_lock)
-    Pod::UI.puts "Caching #{new_podfile_lock}"
+    Pod::UI.puts "Caching new Podfile.lock"
     FileUtils.copy_file(new_podfile_lock, cached_podfile_lock)
   else
-    Pod::UI.puts "Deleting #{cached_podfile_lock}"
+    Pod::UI.puts "Deleting cached Podfile.lock"
     FileUtils.remove_file(cached_podfile_lock, true)
   end
 end
 
 def nuke_frameworks(parent, frameworks)
-  Pod::UI.puts "Nuking frameworks (parent: #{parent}, frameworks: #{frameworks})"
-
   build_dir = File.join(parent, "build")
   rome_dir = File.join(parent, "Rome")
   new_podfile_lock = File.join(parent, "Podfile.lock")
   cached_podfile_lock = File.join(rome_dir, "Podfile.lock")
 
   if File.file?(new_podfile_lock) and File.file?(cached_podfile_lock) and FileUtils.identical?(new_podfile_lock, cached_podfile_lock)
-    Pod::UI.puts "#{new_podfile_lock} matches #{cached_podfile_lock}"
+    Pod::UI.puts "Podfile.lock did not change, not nuking frameworks"
   else
-    Pod::UI.puts "#{new_podfile_lock} does not match #{cached_podfile_lock}"
-    Pod::UI.puts "Nuking #{build_dir}"
+    Pod::UI.puts "Podfile.lock did change, nuking frameworks"
     FileUtils.remove_dir(build_dir, true)
-    Pod::UI.puts "Nuking #{rome_dir}"
     FileUtils.remove_dir(rome_dir, true)
   end
 end

--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -162,8 +162,8 @@ def exclude_simulator_archs(installer)
 end
 
 def cache_frameworks(parent)
-  new_podfile_lock = parent + "Podfile.lock"
-  cached_podfile_lock = parent + "Rome" + "Podfile.lock"
+  new_podfile_lock = File.join(parent, "Podfile.lock")
+  cached_podfile_lock = File.join(parent, "Rome", "Podfile.lock")
 
   if File.file?(new_podfile_lock)
     Pod::UI.puts "Caching #{new_podfile_lock}"
@@ -177,10 +177,10 @@ end
 def nuke_frameworks(parent, frameworks)
   Pod::UI.puts "Nuking frameworks (parent: #{parent}, frameworks: #{frameworks})"
 
-  build_dir = parent + "build"
-  rome_dir = parent + "Rome"
-  new_podfile_lock = parent + "Podfile.lock"
-  cached_podfile_lock = rome_dir + "Podfile.lock"
+  build_dir = File.join(parent, "build")
+  rome_dir = File.join(parent, "Rome")
+  new_podfile_lock = File.join(parent, "Podfile.lock")
+  cached_podfile_lock = File.join(rome_dir, "Podfile.lock")
 
   if File.file?(new_podfile_lock) and File.file?(cached_podfile_lock) and FileUtils.identical?(new_podfile_lock, cached_podfile_lock)
     Pod::UI.puts "#{new_podfile_lock} matches #{cached_podfile_lock}"

--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -161,7 +161,7 @@ def exclude_simulator_archs(installer)
   installer.pods_project.save
 end
 
-def cache_frameworks(parent)
+def cache_podslockfile(parent)
   new_podfile_lock = File.join(parent, "Podfile.lock")
   cached_podfile_lock = File.join(parent, "Rome", "Podfile.lock")
 
@@ -174,7 +174,7 @@ def cache_frameworks(parent)
   end
 end
 
-def nuke_frameworks(parent, frameworks)
+def nuke_frameworks_if_needed(parent, frameworks)
   build_dir = File.join(parent, "build")
   rome_dir = File.join(parent, "Rome")
   new_podfile_lock = File.join(parent, "Podfile.lock")
@@ -211,7 +211,7 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
   build_dir = sandbox_root.parent + 'build'
   destination = sandbox_root.parent + 'Rome'
 
-  nuke_frameworks(sandbox_root.parent, build_dir)
+  nuke_frameworks_if_needed(sandbox_root.parent, build_dir)
 
   fw_type = is_static ? "static" : "dynamic"
   Pod::UI.puts "Building #{fw_type} frameworks"
@@ -256,7 +256,7 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
 
   copy_dsym_files(sandbox_root.parent + 'dSYM', configuration) if enable_dsym
 
-  cache_frameworks(sandbox_root.parent)
+  cache_podslockfile(sandbox_root.parent)
   cleanup(build_dir)
 
   if user_options["post_compile"]

--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -174,7 +174,7 @@ def cache_podslockfile(parent)
   end
 end
 
-def nuke_frameworks_if_needed(parent, frameworks)
+def nuke_frameworks_if_needed(parent)
   build_dir = File.join(parent, "build")
   rome_dir = File.join(parent, "Rome")
   new_podfile_lock = File.join(parent, "Podfile.lock")
@@ -211,7 +211,7 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
   build_dir = sandbox_root.parent + 'build'
   destination = sandbox_root.parent + 'Rome'
 
-  nuke_frameworks_if_needed(sandbox_root.parent, build_dir)
+  nuke_frameworks_if_needed(sandbox_root.parent)
 
   fw_type = is_static ? "static" : "dynamic"
   Pod::UI.puts "Building #{fw_type} frameworks"


### PR DESCRIPTION
This PR makes Rome nuke the built frameworks if the Podfile.lock file has changed.
This way caches won't have to be cleared manually, which is especially useful for CI.